### PR TITLE
Ungroup Scaml from HTML

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5120,8 +5120,8 @@ Scala:
   - scala
   language_id: 341
 Scaml:
-  group: HTML
   type: markup
+  color: "#993333"
   extensions:
   - ".scaml"
   tm_scope: source.scaml


### PR DESCRIPTION
Ungroups Scaml from HTML. Continuation of #4979 and similar PRs.

Color `#993333` from docs: https://scalate.github.io/scalate/documentation/scaml-reference.html